### PR TITLE
Remove locals from trace backs

### DIFF
--- a/meilisearch_cli/documents.py
+++ b/meilisearch_cli/documents.py
@@ -19,7 +19,7 @@ from meilisearch_cli._helpers import (
     validate_file_type_and_set_content_type,
 )
 
-install(show_locals=True)
+install()
 app = Typer()
 
 

--- a/meilisearch_cli/dump.py
+++ b/meilisearch_cli/dump.py
@@ -8,7 +8,7 @@ from typer import Argument, Option, Typer
 from meilisearch_cli._config import MASTER_KEY_HELP_MESSAGE, URL_HELP_MESSAGE, console
 from meilisearch_cli._helpers import create_client, create_panel
 
-install(show_locals=True)
+install()
 app = Typer()
 
 

--- a/meilisearch_cli/index.py
+++ b/meilisearch_cli/index.py
@@ -17,7 +17,7 @@ from meilisearch_cli._helpers import (
     process_request,
 )
 
-install(show_locals=True)
+install()
 app = Typer()
 
 

--- a/meilisearch_cli/main.py
+++ b/meilisearch_cli/main.py
@@ -24,7 +24,7 @@ from meilisearch_cli._helpers import (
     set_search_param,
 )
 
-install(show_locals=True)
+install()
 app = Typer()
 app.add_typer(documents.app, name="documents", help="Manage documents in an index.")
 app.add_typer(dump.app, name="dump", help="Create and get status of dumps.")


### PR DESCRIPTION
Removing `show_locals` from trace backs since master key is included.